### PR TITLE
fix letter case differences between module path and namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "extra": {
     "oxideshop": {
-      "target-directory": "vt/staticbrutto"
+      "target-directory": "vt/StaticBrutto"
     }
   }
 }


### PR DESCRIPTION
leads to unloadable files due to invalid file paths in operating systems that are case sensitive